### PR TITLE
#40 検知範囲（距離）を実装 その他色々

### DIFF
--- a/Cockroach/Cockroach.js
+++ b/Cockroach/Cockroach.js
@@ -5,9 +5,11 @@ class Cockroach {
         this._id = id;
         this._x  = x;
         this._y  = y;
-		this._r  = r;
+		this._direction(r);
 		this._name = name;
-    	this._v  = 0.1;
+		this._v  = 0.1;
+		this._notFoundCnt = 0;
+		this._collistionTime = 0;
     }
 
     run() {
@@ -38,15 +40,32 @@ class Cockroach {
 
         if(col_deg != false) {
 			//ぶつかったら衝突動作
-            this._r = (this._r + col_deg) / 2;
-        } //else {
+			this._direction((this._r + col_deg) / 2);
+			this._collistionTime = 10
+        } else if (this._collistionTime > 0) {
+			//ぶつかった後一定時間方向転換禁止
+			this._collistionTime--;
+		} else {
 			//ぶつからなければ集まれ動作
-			this.measure();
-			let dirs = Common.array_column(this._rel_coods, 'rel_cood');
-			this._r += Common.avg_vec(dirs);
-//        }
+			let cDegs = World.search(this);
+			if (cDegs.length == 0 && this._notFoundCnt > 100) {
+				//いつまでも他のゴキが見つからない場合は強制反転
+				this._rotate(180);
+				this._notFoundCnt = 0;
+			} else if (cDegs.length == 0) {
+				//見える範囲に他のゴキがいない場合はランダム移動
+				this._rotate(Common.getRandomInt(10));
+				this._notFoundCnt++;
+			} else {
+				//平均を算出してみんながたくさんいそうな方向へ進む
+				let degs = Common.array_column(cDegs, 'rel_cood');
+				let ave = degs.reduce((total, deg) => total + deg, 0) / degs.length;
+				this._rotate(ave);
+				this._notFoundCnt = 0;
+			}
+        }
 		
-		this.move();
+		this._move();
 	}
 
 	//直線にならう
@@ -60,36 +79,52 @@ class Cockroach {
 
 			if(col_deg != false) {
 				//ぶつかったら衝突動作
-				this.rebound(col_deg);
+				this._rebound(col_deg);
 	        }
 
 			//ぶつからなければ1列動作
-			this.measure();
+			this._measure();
         	let tmp = Common.array_search(this._rel_coods, 'id', this._id - 1);
-			this._r += tmp['rel_cood'];
+			this._rotate(tmp['rel_cood']);
 		}
 
-		this.move();
+		this._move();
     }
 
 	//ランダムに進む
     randomMove() {
-        this._r += Common.getRandomInt(10);
+        this._rotate(Common.getRandomInt(10));
 		let col_deg = World.collision(this);
         if(col_deg != false) {
             //col_deg = (col_deg + 180) % 360; //入れると面白い
-            this._r = (this._r + col_deg) / 2;
+            this._direction((this._r + col_deg) / 2);
 		}
 		
-    	this.move();
+    	this._move();
     }
-
-	//現在の方向に向かって進む
-	move() {
+	/** 現在の方向に向かって進む */
+	_move() {
 		this._x += Math.cos(this._r * Math.PI / 180) * this._v;
         this._y += Math.sin(this._r * Math.PI / 180) * this._v;
-    }
-	rebound(col_deg) {
+	}
+	/** 
+	 * 向きの直接設定
+	 * 右を0度として0度~+359度の範囲に置換して設定
+	 */
+	_direction(r) {
+		//マイナスの場合はプラスに変換
+		if (r < 0) r = r % 360 + 360;
+		this._r = r % 360;
+	}
+	/**
+	 * 自身の向いている方向を基準とした向きの変更
+	 * 正数:反時計回り
+	 * 負数:時計回り
+	 */
+	_rotate(r) {
+		this._direction(this._r + r);
+	}
+	_rebound(col_deg) {
 		this._x += Math.cos(col_deg * Math.PI / 180) * 3.5;
         this._y += Math.sin(col_deg * Math.PI / 180) * 3.5;
     }
@@ -105,7 +140,7 @@ class Cockroach {
 	 * 自身の進行方向を0°、反時計回りに0°～360°角度が増える
 	 * 全ゴキブリ分のデータ保持
 	 */
-    measure() {
+    _measure() {
     	this._rel_coods = [];
         for (let i in cockroaches) {
         	if (this == cockroaches[i]) {
@@ -119,6 +154,5 @@ class Cockroach {
         	tmp['rel_cood'] = rel_cood;
         	this._rel_coods.push(tmp);
         }
-    	//console.log(this._rel_coods);
     }
 }

--- a/Cockroach/World.js
+++ b/Cockroach/World.js
@@ -1,32 +1,85 @@
 'use strict';
 
 class World {
+
     /** 当たり判定 */
     static collision(cockroach) {
         let r = 2;          //あたり判定円大きさ
         let col_cnt = 0;    //あたり判定
         let col_deg = 0;    //あたり角度合計 falseの場合は衝突なし
-        for (let i in cockroaches) {
-            if (cockroach == cockroaches[i]) continue;
-            let dx = cockroach.x - cockroaches[i].x;
-            let dy = cockroach.y - cockroaches[i].y;
-//            let dx = cockroaches[i].x - cockroach.x;
-//            let dy = cockroaches[i].y - cockroach.y;
 
-            //半径よりおおきければOK
-            let d = dx * dx + dy * dy;
-            if (d > r * r) continue;
+        cockroaches.forEach(function(other) {
+            if (cockroach == other) return;
+            if (!World.inCircleRange(cockroach, other, r)) return;
+
+            let dx = cockroach.x - other.x;
+            let dy = cockroach.y - other.y;
 
             //あたり角度を合算
             col_deg += Common.rel_deg(dx, dy);
             col_cnt += 1;
-        }
+        });
+
         //複数点にあたった場合はその平均角度を返す
         if(col_cnt > 0) return col_deg / col_cnt;
         return false;
     }
 
+    /** 
+     * 引数で渡されたゴキを基準に見える範囲のゴキを探索
+     * 見つけたゴキの角度を返却
+     * 基準となるゴキの進行方向を0°、反時計回りに0°～360°角度が増える
+     */
+    static search(cockroach) {
+        let foundCockroaches = [];
+        cockroaches.forEach(function(other) {
+            if (cockroach == other) return;
+            if (!World.inCircleRange(cockroach, other, World.detectionRange)) return;
+            let tmp = [];
+            tmp['id'] = other.id;
+            tmp['rel_cood'] = World.calcRelativeDeg(cockroach.r, World.calcAbsoluteDeg(cockroach, other));
+            foundCockroaches.push(tmp);
+        });
+
+        return foundCockroaches;
+    }
+
+    /** 
+     * 自身の向いてる方向を基準とした対象との角度を算出（対象との最短角度）
+     * 引数:0度〜+359度の範囲
+	 * 戻り値正数:反時計回り
+	 * 戻り値負数:時計回り
+     */
+    static calcRelativeDeg(baseRDeg, targetRDeg) {
+        let val = (targetRDeg - baseRDeg) % 360;
+        //180度を超える場合は逆回りの角度を算出
+        if (Math.abs(val) > 180) val = 360 - Math.abs(val);
+
+        return val;
+    }
+    /** 
+     * 基準ゴキの右を0度として対象ゴキ位置の角度を算出
+     * 戻り値:0度〜+359度の範囲
+     */
+	static calcAbsoluteDeg(baseCockroach, targetCockroach) {
+		let dx = baseCockroach.x - targetCockroach.x;
+		let dy = baseCockroach.y - targetCockroach.y;
+
+		return (Math.atan2(dy, dx) / Math.PI * 180 + 180) % 360;
+	}
+
+    /** 円範囲判定 */
+    static inCircleRange(baseCockroach, targetCockroach, r) {
+        let dx = baseCockroach.x - targetCockroach.x;
+        let dy = baseCockroach.y - targetCockroach.y;
+        let d = dx * dx + dy * dy;
+
+        return d < r * r;
+    }
+
     /** モード */
     static get mode() {return this._mode;}
     static set mode(val) {this._mode = val;}
+    /** 検知範囲 */
+    static get detectionRange() {return 20;}
 }

--- a/Cockroach/view.js
+++ b/Cockroach/view.js
@@ -31,10 +31,6 @@ var c,
 ******************************************************************************/
 
 function init() {
-
-	
-	
-	
 	c        = document.getElementById('canvas');
 	wrap     = document.getElementById('wrap');
 	cockroach_select = document.getElementById('cockroach_select');
@@ -62,7 +58,7 @@ function init() {
 	//ブラウザリサイズ対応
 	window.addEventListener('resize', resize);
 	
-	World.mode = 0;
+	World.mode = 1;
 	
 	init_data();
 
@@ -146,6 +142,9 @@ function draw_proc() {
 		ctx.rotate(cockroach.r * Math.PI / 180);
 		ctx.translate( - pos[0], - pos[1] ) ;
 
+		//検知範囲描画
+		draw_dottedLineCircle(pos[0], pos[1], World.detectionRange / g_camera_z);
+
 		pos = cal_pos(cockroach.x - 1, cockroach.y + 1.5);
 		ctx.lineWidth = 2;
 		ctx.font = "15px 'Arial'";
@@ -161,6 +160,18 @@ function draw_line(x1, y1, x2, y2) {
 	ctx.moveTo(sp[0], sp[1]);
 	ctx.lineTo(ep[0], ep[1]);
 	ctx.stroke();
+}
+
+function draw_dottedLineCircle(x, y, r) {
+	//分割数
+	let splitNum = 72;
+	for (let i = 0; i < splitNum * 2; i++) {
+		if (i % 2 == 0)continue;
+		ctx.beginPath();
+		//ラジアン角で算出
+		ctx.arc(x, y, r, i / splitNum * Math.PI, (i + 1) / splitNum * Math.PI, false);
+		ctx.stroke();
+	}
 }
 
 function cal_pos(pos_x, pos_y) {


### PR DESCRIPTION
覚書
■全体に関わる変更
・Cockroachの向いてる方向（_r）を0〜359度の範囲が必ず設定されるよう変更
・動くなモードを初期値に変更

■中途半端になってるとこ
・検知範囲（距離）を使った動作の実装は集まれモードにしか入れてない
・世界を見て自分と相手との角度を取ろうとしたのでsearch()をWorldに実装したが、元々あったCockroach._measure()がそのままになってる
・Cockroach.lineupMove()がそのまま
・Common.rel_deg()の+360が何を計算するためなのか判断つかなかったからそのまま
（そしてWorldに似たようなこと書いてる関数（calcAbsoluteDeg()）が増えた（+360⇨+180の差））
・Common.rel_deg()がよくわからなかったからWorld.collision()の使用箇所もそのまま